### PR TITLE
Clean up app env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,20 +5,16 @@ JWKS_URI=https://citadel.demo.aserto.com/dex/keys
 OIDC_ISSUER=https://citadel.demo.aserto.com/dex
 OIDC_CLIENT_ID=citadel-app
 
-ASERTO_POLICY_INSTANCE_NAME=todo-rebac
-ASERTO_POLICY_INSTANCE_LABEL=todo-rebac
-ASERTO_POLICY_ROOT=todoApp
+POLICY_ROOT=todoApp
 
-ASERTO_TENANT_ID={Your Aserto Tenant ID guid}
-ASERTO_AUTHORIZER_API_KEY={REQUIRED: Your Authorizer API Key}
 
-# If you are running your own authorizer, use the following two variables to provide its address
-# and SSL certificate.
-# ASERTO_AUTHORIZER_SERVICE_URL={Authorizer service - defaults to https://authorizer.prod.aserto.com, can use https://localhost:8383 for onebox}
-# ASERTO_AUTHORIZER_CERT_PATH={If using https://localhost:8383 as onebox authorizer, set to $HOME/.config/aserto/aserto-one/certs/gateway-ca.crt}
+AUTHORIZER_SERVICE_URL=https://localhost:8282
+AUTHORIZER_CERT_PATH=$HOME/.config/topaz/certs/grpc-ca.crt
 
-ASERTO_DIRECTORY_API_KEY={Required: Your Aserto directory API key}
+DIRECTORY_GRPC_ADDRESS=localhost:9292
+DIRECTORY_GRPC_CERT_PATH=$HOME/.config/topaz/certs/grpc-ca.crt
 
-# If you are running your own directory, use the following two variables to provide its address
-# ASERTO_DIRECTORY_GRPC_ADDRESS=directory.prod.aserto.com:8443
-# ASERTO_DIRECTORY_GRPC_CERT_PATH={Path to directory certificate}
+# ASERTO_TENANT_ID={Your Aserto Tenant ID guid}
+# ASERTO_AUTHORIZER_API_KEY={REQUIRED: Your Authorizer API Key}
+# ASERTO_POLICY_INSTANCE_NAME=todo-rebac
+# ASERTO_POLICY_INSTANCE_LABEL=todo-rebac

--- a/directory.py
+++ b/directory.py
@@ -12,8 +12,8 @@ from aserto.directory.reader.v2 import GetObjectRequest, GetObjectResponse, GetR
 DEFAULT_DIRECTORY_ADDRESS = "directory.prod.aserto.com:8443"
 
 
-address = os.getenv("ASERTO_DIRECTORY_GRPC_ADDRESS", DEFAULT_DIRECTORY_ADDRESS)
-cert = os.getenv("ASERTO_DIRECTORY_CERT_PATH")
+address = os.getenv("DIRECTORY_GRPC_ADDRESS", DEFAULT_DIRECTORY_ADDRESS)
+cert = os.path.expandvars(os.getenv("DIRECTORY_GRPC_CERT_PATH", ""))
 api_key = os.getenv("ASERTO_DIRECTORY_API_KEY")
 tenant_id = os.getenv("ASERTO_TENANT_ID")
 

--- a/options.py
+++ b/options.py
@@ -8,9 +8,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-ASERTO_AUTHORIZER_URL = "https://authorizer.prod.aserto.com"
+DEFAULT_AUTHORIZER_URL = "https://authorizer.prod.aserto.com"
 
-__all__ = ["AsertoMiddlewareOptions", "load_aserto_options_from_environment"]
+__all__ = ["AsertoMiddlewareOptions", "load_options_from_environment"]
 
 
 class AsertoMiddlewareOptions(TypedDict):
@@ -21,25 +21,19 @@ class AsertoMiddlewareOptions(TypedDict):
     identity_provider: Callable[[], Awaitable[Identity]]
 
 
-def load_aserto_options_from_environment() -> AsertoMiddlewareOptions:
+def load_options_from_environment() -> AsertoMiddlewareOptions:
     missing_variables = []
 
 
     authorizer_service_url = os.getenv(
-        "ASERTO_AUTHORIZER_SERVICE_URL", ASERTO_AUTHORIZER_URL
+        "AUTHORIZER_SERVICE_URL", DEFAULT_AUTHORIZER_URL
     )
 
-    tenant_id = os.getenv("ASERTO_TENANT_ID", None)
-    authorizer_api_key = os.getenv("ASERTO_AUTHORIZER_API_KEY", "")
-
-    policy_instance_name = os.getenv("ASERTO_POLICY_INSTANCE_NAME", "")
-    policy_instance_label = os.getenv("ASERTO_POLICY_INSTANCE_LABEL", "")
-
-    policy_path_root = os.getenv("ASERTO_POLICY_ROOT", "")
+    policy_path_root = os.getenv("POLICY_ROOT", "")
     if not policy_path_root:
-        missing_variables.append("ASERTO_POLICY_ROOT")
+        missing_variables.append("POLICY_ROOT")
 
-    cert_file_path = os.getenv("ASERTO_AUTHORIZER_CERT_PATH")
+    cert_file_path = os.path.expandvars(os.getenv("AUTHORIZER_CERT_PATH", ""))
 
     oidc_issuer = os.getenv("OIDC_ISSUER", "")
     if not oidc_issuer:
@@ -48,6 +42,11 @@ def load_aserto_options_from_environment() -> AsertoMiddlewareOptions:
     oidc_client_id = os.getenv("OIDC_CLIENT_ID", "")
     if not oidc_client_id:
         missing_variables.append("OIDC_CLIENT_ID")
+
+    tenant_id = os.getenv("ASERTO_TENANT_ID", None)
+    authorizer_api_key = os.getenv("ASERTO_AUTHORIZER_API_KEY", "")
+    policy_instance_name = os.getenv("ASERTO_POLICY_INSTANCE_NAME", "")
+    policy_instance_label = os.getenv("ASERTO_POLICY_INSTANCE_LABEL", "")
 
 
     if missing_variables:

--- a/server.py
+++ b/server.py
@@ -4,7 +4,7 @@ from flask_cors import CORS
 from .directory import user_from_identity
 from .db import list_todos, insert_todo, update_todo, delete_todo
 from flask_aserto import AsertoMiddleware, AuthorizationError
-from .aserto_options import load_aserto_options_from_environment
+from .options import load_options_from_environment
 
 from dotenv import load_dotenv
 
@@ -14,7 +14,7 @@ app = Flask(__name__)
 
 CORS(app, headers=["Content-Type", "Authorization"])
 
-aserto_options = load_aserto_options_from_environment()
+aserto_options = load_options_from_environment()
 aserto = AsertoMiddleware(**aserto_options)
 
 
@@ -66,7 +66,6 @@ def remove_todo(ownerID):
 @aserto.authorize
 def get_user(userID):
     user= user_from_identity(userID)
-    app.logger.warning("user: %s", user)
     return jsonify(user)
 
 


### PR DESCRIPTION
* Add `FLASK_APP=server.py`
* Remove `ASERTO_` prefixes
* Target local Topaz authorizer by default.