### PR TITLE
Match .env vars with console-generated names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,10 @@ FLASK_RUN_PORT=3001
 FLASK_APP=server.py
 
 JWKS_URI=https://citadel.demo.aserto.com/dex/keys
-OIDC_ISSUER=https://citadel.demo.aserto.com/dex
-OIDC_CLIENT_ID=citadel-app
+ISSUER=https://citadel.demo.aserto.com/dex
+CLIENT_ID=citadel-app
 
-POLICY_ROOT=todoApp
+ASERTO_POLICY_ROOT=todoApp
 
 # Topaz
 #
@@ -23,5 +23,5 @@ DIRECTORY_GRPC_CERT_PATH=$HOME/.config/topaz/certs/grpc-ca.crt
 # ASERTO_TENANT_ID={Your Aserto Tenant ID guid}
 # ASERTO_AUTHORIZER_API_KEY={Your Authorizer API Key}
 # ASERTO_DIRECTORY_API_KEY={You Directory (read-only) API Key}
-# ASERTO_POLICY_INSTANCE_NAME=policy-todo
-# ASERTO_POLICY_INSTANCE_LABEL=policy-todo
+# ASERTO_POLICY_INSTANCE_NAME=todo-rebac
+# ASERTO_POLICY_INSTANCE_LABEL=todo-rebac

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ FLASK_APP=server.py
 
 JWKS_URI=https://citadel.demo.aserto.com/dex/keys
 ISSUER=https://citadel.demo.aserto.com/dex
-CLIENT_ID=citadel-app
+AUDIENCE=citadel-app
 
 ASERTO_POLICY_ROOT=todoApp
 
@@ -23,5 +23,5 @@ DIRECTORY_GRPC_CERT_PATH=$HOME/.config/topaz/certs/grpc-ca.crt
 # ASERTO_TENANT_ID={Your Aserto Tenant ID guid}
 # ASERTO_AUTHORIZER_API_KEY={Your Authorizer API Key}
 # ASERTO_DIRECTORY_API_KEY={You Directory (read-only) API Key}
-# ASERTO_POLICY_INSTANCE_NAME=todo-rebac
-# ASERTO_POLICY_INSTANCE_LABEL=todo-rebac
+# ASERTO_POLICY_INSTANCE_NAME=todo
+# ASERTO_POLICY_INSTANCE_LABEL=todo

--- a/directory.py
+++ b/directory.py
@@ -12,7 +12,7 @@ from aserto.directory.reader.v2 import GetObjectRequest, GetObjectResponse, GetR
 DEFAULT_DIRECTORY_ADDRESS = "directory.prod.aserto.com:8443"
 
 
-address = os.getenv("DIRECTORY_GRPC_ADDRESS", DEFAULT_DIRECTORY_ADDRESS)
+address = os.getenv("ASERTO_DIRECTORY_SERVICE_URL", DEFAULT_DIRECTORY_ADDRESS)
 cert = os.path.expandvars(os.getenv("DIRECTORY_GRPC_CERT_PATH", ""))
 api_key = os.getenv("ASERTO_DIRECTORY_API_KEY")
 tenant_id = os.getenv("ASERTO_TENANT_ID")

--- a/options.py
+++ b/options.py
@@ -26,22 +26,22 @@ def load_options_from_environment() -> AsertoMiddlewareOptions:
 
 
     authorizer_service_url = os.getenv(
-        "AUTHORIZER_SERVICE_URL", DEFAULT_AUTHORIZER_URL
+        "ASERTO_AUTHORIZER_SERVICE_URL", DEFAULT_AUTHORIZER_URL
     )
 
-    policy_path_root = os.getenv("POLICY_ROOT", "")
+    policy_path_root = os.getenv("ASERTO_POLICY_ROOT", "")
     if not policy_path_root:
-        missing_variables.append("POLICY_ROOT")
+        missing_variables.append("ASERTO_POLICY_ROOT")
 
     cert_file_path = os.path.expandvars(os.getenv("AUTHORIZER_CERT_PATH", "")) or None
 
-    oidc_issuer = os.getenv("OIDC_ISSUER", "")
+    oidc_issuer = os.getenv("ISSUER", "")
     if not oidc_issuer:
-        missing_variables.append("OIDC_ISSUER")
+        missing_variables.append("ISSUER")
 
-    oidc_client_id = os.getenv("OIDC_CLIENT_ID", "")
+    oidc_client_id = os.getenv("AUDIENCE", "")
     if not oidc_client_id:
-        missing_variables.append("OIDC_CLIENT_ID")
+        missing_variables.append("AUDIENCE")
 
     tenant_id = os.getenv("ASERTO_TENANT_ID", None)
     authorizer_api_key = os.getenv("ASERTO_AUTHORIZER_API_KEY", "")


### PR DESCRIPTION
This PR renames environment variables to match the names in the `.env` file generated by the console in the getting started and Quickstart apps.